### PR TITLE
Fix split_obj_identified to handle pk's containing '.'

### DIFF
--- a/haystack_rqueue/signals.py
+++ b/haystack_rqueue/signals.py
@@ -31,9 +31,9 @@ def split_obj_identifier(obj_identifier):
     if len(bits) < 2:
         return (None, None)
 
-    pk = bits[-1]
+    pk = '.'.join(bits[2:])
     # In case Django ever handles full paths...
-    object_path = '.'.join(bits[:-1])
+    object_path = '.'.join(bits[0:2])
     return (object_path, pk)
 
 


### PR DESCRIPTION
I've encounted an issue with the object having the pk's truncated when using a pk containing '.', as in my case, IPv4 addresses.
